### PR TITLE
Update static-howto.markdown

### DIFF
--- a/doc/static-howto.markdown
+++ b/doc/static-howto.markdown
@@ -1,4 +1,4 @@
-﻿Static files with Tntnet
+Static files with Tntnet
 ========================
 
 Introduction


### PR DESCRIPTION
Removing BOM (byte order mark) from BOF, in order to fix sorting on the tntnet websites howto page

Hopefully the github webeditor did save this correctly. Otherwise `tail -c +4 static-howto.markdown` on the original file does the trick.
