### PR TITLE
added compression handling for already compressed files in mbcomponent

### DIFF
--- a/framework/common/tnt/mbcomponent.h
+++ b/framework/common/tnt/mbcomponent.h
@@ -31,6 +31,7 @@
 #define TNT_MBCOMPONENT_H
 
 #include <tnt/ecpp.h>
+#include <tnt/data.h>
 #include <vector>
 #include <cxxtools/mutex.h>
 
@@ -83,6 +84,7 @@ namespace tnt
 
   private:
       unsigned doCall(tnt::HttpRequest& request, tnt::HttpReply& reply, tnt::QueryParams& qparam, bool top);
+      unsigned searchFile(const std::string& url, const tnt::DataChunks& data) const;
   };
 }
 


### PR DESCRIPTION
This commit changes the behavior of files in the mbcomponent: 
If enableCompression is set and client supports compression, mbcomponent is looking for the requested filename with the extension .gz at first, if this file is found, this already compressed file would be sent to the client.
if there is no file with the extension .gz than the current file would be compressed on the fly (as it was before) and sent to the client.

Example: client wants favicon.svg, with compression enabled.
server looks for favicon.svg.gz ==> if found, server sends this compressed file. (this is the new behavior)
if favicon.svg.gz not found, server will compress favicon.svg and send it compressed to the client. (this is the old behavior, now the fallback)