### PR TITLE
fix make stop error

### DIFF
--- a/misc/Makefile.am
+++ b/misc/Makefile.am
@@ -33,7 +33,7 @@ nobase_dist_pkgdata_DATA = \
 	template/mvc-standalone/Makefile.am \
 	template/mvc-standalone/model/index.ecpp \
 	template/mvc-standalone/@PROJECT@.conf \
-	template/mvc-standalone/README \
+	template/mvc-standalone/README.md \
 	template/mvc-standalone/resources/@PROJECT@.css \
 	template/mvc-standalone/view/index.ecpp \
 	template/mvc-standalone/webmain.ecpp


### PR DESCRIPTION
compilation of tntnet stopped with below message due to a wrong file name in nobase_dist_pkgdata_DATA.

make[1]: *** No rule to make target `template/mvc-standalone/README', needed by `all-am'.  Stop.
