### PR TITLE
set openssl options : Cipher, Protocols and temp ECDH key

### DIFF
--- a/framework/common/tnt/openssl.h
+++ b/framework/common/tnt/openssl.h
@@ -66,6 +66,7 @@ namespace tnt
   class OpensslServer : public cxxtools::net::TcpServer
   {
       SslCtxPtr _ctx;
+      void setOptions();
       void installCertificates(const char* certificateFile, const char* privateKeyFile);
 
     public:

--- a/framework/common/tnt/tntconfig.h
+++ b/framework/common/tnt/tntconfig.h
@@ -484,6 +484,24 @@ namespace tnt
      */
     std::vector<std::string> includes;
 
+    /** Restrict the list of SSL ciphers
+        The format of the string is described in https://www.openssl.org/docs/manmaster/apps/ciphers.html
+        default: (none)  
+     */
+    std::string sslCipherList;
+
+    /** Restrict the list of SSL protocols
+        +SSLv3 enable SSLv3
+        -SSLv3 disable SSLv3
+        +TLSv1_0 enable TLSv1
+        -TLSv1_0 disable TLSv1
+        +TLSv1_1 enable TLSv1.1
+        -TLSv1_1 disable TLSv1.1
+        +TLSv1_2 enable TLSv1.2
+        -TLSv1_2 disable TLSv1.2
+     */
+    std::string sslProtocols;
+
     /// Create a %TntConfig object with default configuration
     TntConfig();
 

--- a/framework/common/tntconfig.cpp
+++ b/framework/common/tntconfig.cpp
@@ -195,6 +195,8 @@ namespace tnt
     si.getMember("reuseAddress", config.reuseAddress);
     si.getMember("includes", config.includes);
     si.getMember("logging", config.logConfiguration);
+    si.getMember("sslCipherList", config.sslCipherList);
+    si.getMember("sslProtocols", config.sslProtocols);
 
     config.config = si;
 


### PR DESCRIPTION
Problem : openssl behaves with default weak protocol(SSL3) and weak cipher(RC4)
Solution : add  sslProtocols and sslCipherList tag in tntnet.xml to allow user to configuration it.

Problem : some recent browser likes Chrome reports that “Your connection to tntnet server is encrypted with obsolete cryptography.”
To avoid this kind of message, it is good to allow openssl using ECDHE cipher suite.
Solution : create a temp ECDH keys.

