### PR TITLE
When doing setuid(), optionally also pick up supplementary groups of that user

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,28 @@ AC_COMPILE_IFELSE(
 int flag = cxxtools::net::TcpServer::REUSEADDR;
 ])], AC_DEFINE(HAVE_CXXTOOLS_REUSEADDR, [], [Defined if cxxtools supports SO_REUSEADDR flag]))
 
+AC_MSG_CHECKING([if system provides getgrouplist() with semantics we expect])
+AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE([
+#include <grp.h>
+#include <pwd.h>
+struct passwd pw;
+gid_t groups;
+int foundgroups = 1;
+int gotgroups = getgrouplist("username", pw.pw_gid, &groups, &foundgroups);
+])], AC_DEFINE(HAVE_GETGROUPLIST, [1], [Defined if system provides getgrouplist() with semantics we expect])
+     AC_MSG_RESULT([yes]), AC_MSG_RESULT([no]))
+
+AC_MSG_CHECKING([if system provides setgroups() with semantics we expect])
+AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE([
+#include <grp.h>
+#include <pwd.h>
+gid_t groups;
+int errcode = setgroups(1, &groups);
+])], AC_DEFINE(HAVE_SETGROUPS, [1], [Defined if system provides setgroups() with semantics we expect])
+     AC_MSG_RESULT([yes]), AC_MSG_RESULT([no]))
+
 AC_ARG_WITH([epoll],
   AS_HELP_STRING([--with-epoll=yes|no|probe], [use epoll]),
   [epoll_option=$withval],

--- a/demo/mvc/tntnet.xml
+++ b/demo/mvc/tntnet.xml
@@ -80,6 +80,7 @@
   <!-- <maxRequestSize>65536</maxRequestSize> -->
   <!-- <maxRequestTime>600</maxRequestTime> -->
   <!-- <user>tntnet</user> -->
+  <!-- <allUserGroups>no</allUserGroups> -->
   <!-- <group>tntnet</group> -->
   <!-- <dir>/</dir> -->
   <!-- <chrootdir>/var/safedir</chrootdir> -->

--- a/doc/man/tntnet.xml.7
+++ b/doc/man/tntnet.xml.7
@@ -33,6 +33,14 @@ available. Also the \fB\fCcontent\-size\fR can be empty in some cases.
 .fi
 .RE
 .PP
+\fB\fC<allUserGroups>\fR\fIyes|no\fP\fB\fC</allUserGroups>\fR
+.IP
+Specifies that if the \fI<user>\fP is changed for the server process, then the
+groups (primary and secondary) which this account is a member of should
+become the primary GID and supplementary GIDs of this process too.
+.IP
+The legacy default value is \fIno\fP - to avoid surprises during upgrades.
+.PP
 \fB\fC<bufferSize>\fR\fIbytes\fP\fB\fC</bufferSize>\fR
 .IP
 Specifies the number of bytes sent in a single system call. This does not

--- a/doc/man/tntnet.xml.7.markdown
+++ b/doc/man/tntnet.xml.7.markdown
@@ -32,6 +32,14 @@ This section describes the variables, used by Tntnet (8).
 
     <accessLog>/var/log/tntnet/access.log</accessLog
 
+`<allUserGroups>`*yes|no*`</allUserGroups>`
+
+  Specifies that if the `<user>` is changed for the server process, then the
+  groups (primary and secondary) which this account is a member of should
+  become the primary GID and supplementary GIDs of this process too.
+
+  The legacy default value is `no` - to avoid surprises during upgrades.
+
 `<bufferSize>`*bytes*`</bufferSize>`
 
   Specifies the number of bytes sent in a single system call. This does not

--- a/etc/tntnet/tntnet.xml.in
+++ b/etc/tntnet/tntnet.xml.in
@@ -54,6 +54,7 @@
 
   <daemon>1</daemon>
   <user>tntnet</user>
+  <allUserGroups>no</allUserGroups>
   <group>tntnet</group>
   <pidfile>@localstatedir@/run/tntnet.pid</pidfile>
   <documentRoot>/var/www</documentRoot>

--- a/framework/common/tnt/tntconfig.h
+++ b/framework/common/tnt/tntconfig.h
@@ -186,6 +186,21 @@ namespace tnt
      */
     std::string user;
 
+    /** If the "user" string is set correctly as the unix user id of the user tntnet
+        should switch to when executed as root, then if this string is set to "yes"
+        the process would first enlist with any primary and supplementary unix groups
+        this account is registered with locally.
+
+        If this string is unset (empty), or not set to "yes", or tntnet is not executed
+        as root, the user and supplementary group list under which tntnet operates does
+        not change. The switching to additional groups is done through setgroups(), and
+        it happens after setgid() executed by setting the "group" option and before
+        downgrading privileges into the non-root user set by the "user" option.
+
+        default: (empty)
+     */
+    bool allUserGroups;
+
     /** The unix group id of the group tntnet should switch to when executed as root
 
         If this option is unset (empty) or tntnet is not executed as root, the group

--- a/framework/common/tntconfig.cpp
+++ b/framework/common/tntconfig.cpp
@@ -164,6 +164,7 @@ namespace tnt
     si.getMember("maxRequestSize", config.maxRequestSize);
     si.getMember("maxRequestTime", config.maxRequestTime);
     si.getMember("user", config.user);
+    si.getMember("allUserGroups", config.allUserGroups);
     si.getMember("group", config.group);
     si.getMember("dir", config.dir);
     si.getMember("chrootdir", config.chrootdir);
@@ -216,6 +217,7 @@ namespace tnt
   TntConfig::TntConfig()
     : maxRequestSize(0),
       maxRequestTime(600),
+      allUserGroups(false),
       daemon(false),
       minThreads(5),
       maxThreads(100),

--- a/misc/template/classic-module/tntnet.xml
+++ b/misc/template/classic-module/tntnet.xml
@@ -71,6 +71,7 @@
   <!-- <maxRequestSize>65536</maxRequestSize> -->
   <!-- <maxRequestTime>600</maxRequestTime> -->
   <!-- <user>tntnet</user> -->
+  <!-- <allUserGroups>no</allUserGroups> -->
   <!-- <group>tntnet</group> -->
   <!-- <dir>/</dir> -->
   <!-- <chrootdir>/var/safedir</chrootdir> -->

--- a/misc/template/mvc-module/tntnet.xml
+++ b/misc/template/mvc-module/tntnet.xml
@@ -104,6 +104,7 @@
   <!-- <maxRequestSize>65536</maxRequestSize> -->
   <!-- <maxRequestTime>600</maxRequestTime> -->
   <!-- <user>tntnet</user> -->
+  <!-- <allUserGroups>no</allUserGroups> -->
   <!-- <group>tntnet</group> -->
   <!-- <dir>/</dir> -->
   <!-- <chrootdir>/var/safedir</chrootdir> -->

--- a/misc/tntnet-conf2xml.pl
+++ b/misc/tntnet-conf2xml.pl
@@ -21,6 +21,7 @@ my %keywords = (
     MaxRequestSize => 'maxRequestSize',
     MaxRequestTime => 'maxRequestTime',
     User => 'user',
+    AllUserGroups => 'allUserGroups',
     Group => 'group',
     Dir => 'dir',
     Chroot => 'chrootdir',

--- a/misc/tntnet-project.in
+++ b/misc/tntnet-project.in
@@ -109,6 +109,7 @@ EOF
   <!-- <maxRequestSize>65536</maxRequestSize> -->
   <!-- <maxRequestTime>600</maxRequestTime> -->
   <!-- <user>tntnet</user> -->
+  <!-- <allUserGroups>no</allUserGroups> -->
   <!-- <group>tntnet</group> -->
   <!-- <dir>/</dir> -->
   <!-- <chrootdir>/var/safedir</chrootdir> -->


### PR DESCRIPTION
process.cpp : when doing setuid(), optionally also pick up supplementary groups of that user (off by default, to behave like before)