### PR TITLE
Move percents in code sample to the first column

### DIFF
--- a/doc/quick-start-guide.markdown
+++ b/doc/quick-start-guide.markdown
@@ -243,11 +243,11 @@ We change our myfirstproject.ecpp to look like this:
             }>
             <p>
                 <$ arg1 $> + <$ arg2 $> =
-                % if (result == 0.0) {
+    %             if (result == 0.0) {
                     nothing
-                % } else {
+    %             } else {
                     <$ result $>
-                % }
+    %             }
             </p>
         </body>
     </html>
@@ -322,9 +322,9 @@ functional calculator:
                 <input type="text" name="arg1" value="<$arg1$>">
                 +
                 <input type="text" name="arg2" value="<$arg2$>">
-                % if (s1 && s2) { // if both input streams were successful extracting values
+    %             if (s1 && s2) { // if both input streams were successful extracting values
                     = <$ v1 + v2 $>
-                % }
+    %             }
             </form>
         </body>
     </html>


### PR DESCRIPTION
The text says percents should be there and it doesn't work otherwise, so adjust code in examples.

Alternatively, don't add that many spaces between `%` and start of the code, like in files under `examples/`.