### PR TITLE
fix -Wunused-but-set-variable in checkSessionTimeout

### DIFF
--- a/framework/common/scopemanager.cpp
+++ b/framework/common/scopemanager.cpp
@@ -280,7 +280,6 @@ void ScopeManager::checkSessionTimeout()
     time(&currentTime);
     std::unique_lock<std::mutex> lock(_sessionScopesMutex);
     auto it = _sessionScopes.begin();
-    unsigned count = 0;
     while (it != _sessionScopes.end())
     {
         auto s = it->second;
@@ -290,7 +289,6 @@ void ScopeManager::checkSessionTimeout()
             auto it2 = it;
             ++it;
             _sessionScopes.erase(it2);
-            ++count;
         }
         else
           ++it;


### PR DESCRIPTION
The count variable tracks removed sessions but is never read after the loop and has no log or return statement that uses it. Remove the variable and the corresponding increment to silence -Wunused-but-set-variable.