### PR TITLE
fix -Wold-style-definition in fill_fopen_filefunc

### DIFF
--- a/framework/common/ioapi.c
+++ b/framework/common/ioapi.c
@@ -221,8 +221,7 @@ static int ZCALLBACK ferror_file_func (voidpf opaque, voidpf stream)
     return ret;
 }
 
-void fill_fopen_filefunc (pzlib_filefunc_def)
-  zlib_filefunc_def* pzlib_filefunc_def;
+void fill_fopen_filefunc (zlib_filefunc_def* pzlib_filefunc_def)
 {
     pzlib_filefunc_def->zopen_file = fopen_file_func;
     pzlib_filefunc_def->zread_file = fread_file_func;


### PR DESCRIPTION
Convert the K&R-style function definition to a modern prototype declaration to silence -Wold-style-definition.